### PR TITLE
remove unstable packages from safe and balanced profiles

### DIFF
--- a/debloat_balanced.txt
+++ b/debloat_balanced.txt
@@ -8,7 +8,6 @@ pm uninstall -k --user 0 com.amazon.mp3
 pm uninstall -k --user 0 com.amazon.mshop.android
 pm uninstall -k --user 0 com.amazon.mshop.android.shopping
 pm uninstall -k --user 0 com.amazon.venezia
-pm uninstall -k --user 0 com.android.deskclock
 pm uninstall -k --user 0 com.android.providers.downloads.ui
 pm uninstall -k --user 0 com.audible.application
 pm uninstall -k --user 0 com.bitdefender.security
@@ -60,9 +59,7 @@ pm uninstall -k --user 0 com.microsoft.skydrive
 pm uninstall -k --user 0 com.miui.analytics
 pm uninstall -k --user 0 com.miui.audioeffect
 pm uninstall -k --user 0 com.miui.audiomonitor
-pm uninstall -k --user 0 com.miui.backup
 pm uninstall -k --user 0 com.miui.carlink
-pm uninstall -k --user 0 com.miui.cleaner
 pm uninstall -k --user 0 com.miui.compass
 pm uninstall -k --user 0 com.miui.daemon
 pm uninstall -k --user 0 com.miui.extraphoto
@@ -72,8 +69,6 @@ pm uninstall -k --user 0 com.miui.micloudsync
 pm uninstall -k --user 0 com.miui.mishare.connectivity
 pm uninstall -k --user 0 com.miui.misightservice
 pm uninstall -k --user 0 com.miui.misound
-pm uninstall -k --user 0 com.miui.miwallpaper
-pm uninstall -k --user 0 com.miui.miwallpaper.overlay.*
 pm uninstall -k --user 0 com.miui.msa.global
 pm uninstall -k --user 0 com.miui.notes
 pm uninstall -k --user 0 com.miui.notification
@@ -114,7 +109,6 @@ pm uninstall -k --user 0 com.tripledot.solitaire
 pm uninstall -k --user 0 com.vitastudio.mahjong
 pm uninstall -k --user 0 com.vlingo.midas
 pm uninstall -k --user 0 com.xiaomi.discover
-pm uninstall -k --user 0 com.xiaomi.finddevice
 pm uninstall -k --user 0 com.xiaomi.midrop
 pm uninstall -k --user 0 com.xiaomi.mipicks
 pm uninstall -k --user 0 com.xiaomi.mirecycle

--- a/debloat_safe.txt
+++ b/debloat_safe.txt
@@ -8,7 +8,6 @@ pm uninstall -k --user 0 com.amazon.mp3
 pm uninstall -k --user 0 com.amazon.mshop.android
 pm uninstall -k --user 0 com.amazon.mshop.android.shopping
 pm uninstall -k --user 0 com.amazon.venezia
-pm uninstall -k --user 0 com.android.deskclock
 pm uninstall -k --user 0 com.android.providers.downloads.ui
 pm uninstall -k --user 0 com.audible.application
 pm uninstall -k --user 0 com.bitdefender.security
@@ -57,13 +56,9 @@ pm uninstall -k --user 0 com.microsoft.office.outlook
 pm uninstall -k --user 0 com.microsoft.office.powerpoint
 pm uninstall -k --user 0 com.microsoft.office.word
 pm uninstall -k --user 0 com.microsoft.skydrive
-pm uninstall -k --user 0 com.miui.backup
-pm uninstall -k --user 0 com.miui.cleaner
 pm uninstall -k --user 0 com.miui.compass
 pm uninstall -k --user 0 com.miui.extraphoto
 pm uninstall -k --user 0 com.miui.misightservice
-pm uninstall -k --user 0 com.miui.miwallpaper
-pm uninstall -k --user 0 com.miui.miwallpaper.overlay.*
 pm uninstall -k --user 0 com.miui.notes
 pm uninstall -k --user 0 com.miui.notification
 pm uninstall -k --user 0 com.miui.weather2
@@ -89,7 +84,6 @@ pm uninstall -k --user 0 com.tripledot.solitaire
 pm uninstall -k --user 0 com.vitastudio.mahjong
 pm uninstall -k --user 0 com.vlingo.midas
 pm uninstall -k --user 0 com.xiaomi.discover
-pm uninstall -k --user 0 com.xiaomi.finddevice
 pm uninstall -k --user 0 com.xiaomi.midrop
 pm uninstall -k --user 0 com.xiaomi.ugd
 pm uninstall -k --user 0 com.zhiliaoapp.musically


### PR DESCRIPTION
fix(safe,balanced): remove unstable packages from safe and balanced profiles

Removal of these packages can cause bootloops, crashes, or broken
system features on HyperOS devices:
- com.miui.miwallpaper / overlay: crashes wallpaper picker
- com.android.deskclock: alarms killed by battery management
- com.miui.backup: crashes Settings; breaks local restore
- com.xiaomi.finddevice: bootloop risk with Mi Account logged in
- com.miui.cleaner: breaks Security app; bootloop on OTA update

Packages kept in aggressive profile (user accepts higher risk).